### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/hsniama/342faca1-d902-4f02-bc4b-3915311f1163/2b593a8d-3e15-4089-af65-2d34a1f39517/_apis/work/boardbadge/2af67a99-ebec-4b3b-9038-3f6d44f18c58)](https://dev.azure.com/hsniama/342faca1-d902-4f02-bc4b-3915311f1163/_boards/board/t/2b593a8d-3e15-4089-af65-2d34a1f39517/Microsoft.RequirementCategory)
 # gitflow
 Gitflow en GitHub


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/hsniama/342faca1-d902-4f02-bc4b-3915311f1163/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.